### PR TITLE
iOS INVALID callbackId

### DIFF
--- a/src/dronahq.js
+++ b/src/dronahq.js
@@ -6172,8 +6172,8 @@
 
                 // Register the callbacks and add the callbackId to the positional
                 // arguments if given.
+                callbackId = service + cordova.callbackId++;
                 if (successCallback || failCallback) {
-                    callbackId = service + cordova.callbackId++;
                     cordova.callbacks[callbackId] = {
                         success: successCallback,
                         fail: failCallback


### PR DESCRIPTION
In iOSExec() INVALID callbackId was assigned when no success/ error callback function was provided by the methods. INVALID callbackId was resulting into no response/ callback to js from the native app, which was resulting into single immediate execution of the method and other executions only on app background entry.
